### PR TITLE
increase limit

### DIFF
--- a/soundscape/views.py
+++ b/soundscape/views.py
@@ -94,8 +94,8 @@ def get_noise_data(request):
         APP_TOKEN = os.environ.get("NYC_OPEN_DATA_APP_TOKEN")
         headers = {"X-App-Token": APP_TOKEN} if APP_TOKEN else {}
 
-        TOTAL_RECORDS = 1000  # Total records we want to fetch
-        BATCH_SIZE = 200  # API's default/maximum limit per request
+        TOTAL_RECORDS = 2500  
+        BATCH_SIZE = 500
         MAX_WORKERS = 5  # Number of concurrent requests
 
         # Build the where clause

--- a/soundscape/views.py
+++ b/soundscape/views.py
@@ -94,7 +94,7 @@ def get_noise_data(request):
         APP_TOKEN = os.environ.get("NYC_OPEN_DATA_APP_TOKEN")
         headers = {"X-App-Token": APP_TOKEN} if APP_TOKEN else {}
 
-        TOTAL_RECORDS = 2500  
+        TOTAL_RECORDS = 2500
         BATCH_SIZE = 500
         MAX_WORKERS = 5  # Number of concurrent requests
 


### PR DESCRIPTION
"If you don’t provide a $limit parameter in your NYC Open Data API request, the default number of rows returned is 1,000. This is a built-in constraint to ensure efficient data handling." <-- increasing batch size to 500 to test performance. IMO anything below 1000 should be much faster than before. 